### PR TITLE
Remove console.log

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,6 @@ import { ExtensionContext } from 'vscode';
 import { TagManager } from './tagManager';
 
 export function activate(context: ExtensionContext) {
-    console.log('Congratulations, your extension "auto-rename-tag" is now active!');
-
     let tagManager = new TagManager();
     tagManager.run();
 }


### PR DESCRIPTION
Is it necessary to keep this `console.log('Congratulations, your extension "auto-rename-tag" is now active!');` ?