### PR TITLE
Use 'renameOnType' if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ By default, it is `["*"]` and will be activated for all languages.
 }
 ```
 
-**Note:** The setting should be set with language id defined in [VS Code](https://github.com/Microsoft/vscode/tree/master/extensions). Taking [javascript definition](https://github.com/Microsoft/vscode/blob/master/extensions/javascript/package.json) as an example, we need to use `javascript` for `.js` and `.es6`, use `javascriptreact` for `.jsx`. So, if you want to enable this extension on `.js` file, you need to add `javascript` in settings.json.
+The setting should be set with language id defined in [VS Code](https://github.com/Microsoft/vscode/tree/master/extensions). Taking [javascript definition](https://github.com/Microsoft/vscode/blob/master/extensions/javascript/package.json) as an example, we need to use `javascript` for `.js` and `.es6`, use `javascriptreact` for `.jsx`. So, if you want to enable this extension on `.js` file, you need to add `javascript` in settings.json.
+
+## Note
+
+From 1.44, VS Code offers the built-in [Rename On Type](https://code.visualstudio.com/updates/v1_44#_synced-regions) support for HTML and Handlebars that can be enabled with the setting `editor.renameOnType`. If this setting is enabled, this extension will skip HTML and Handlebars files regardless of the languages listed in `auto-rename-tag.activationOnLanguage`
 
 ## Change Log
 


### PR DESCRIPTION
Since 1.44, VS Code offers the built-in [Rename On Type](https://code.visualstudio.com/updates/v1_44#_synced-regions) support for HTML and Handlebars that can be enabled with the setting `editor.renameOnType` (currently turned off by default),

In order to avoid conflict and duplicate computations, this PR changes that if the `editor.renameOnType`. setting is enabled for a given 'html' or 'handlebar' document, the extension skips the document regardless of the languages listed in `auto-rename-tag.activationOnLanguage`