### PR TITLE
Exclude source map from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,1 @@
+packages/**/*.map

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -34,6 +34,8 @@ fs.copyFileSync(
 
 fs.copyFileSync(path.join(root, 'LICENSE'), path.join(root, 'dist/LICENSE'));
 
+fs.copyFileSync(path.join(root, '.vscodeignore'), path.join(root, 'dist/.vscodeignore'));
+
 fs.ensureDirSync(path.join(root, 'dist/images'));
 fs.copyFileSync(
   path.join(root, 'images/logo.png'),


### PR DESCRIPTION
First of all, thanks for this simple but effective extension! There's just one problem with it, the extension size is a little too much compared to its functionality. On my system, the unpacked size is 2.6MB.

This pull request excludes the source maps from the extension package, which is down from 668.97KB to 196.4KB!